### PR TITLE
Allow read-only access to the icons directories and change XCURSOR_PATH to match

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -24,7 +24,6 @@ finish-args:
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
   - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
   - --filesystem=~/.local/share/icons:ro # Needed for correct cursors on wayland 
-  - --filesystem=/usr/share/icons:ro
   - --env=XCURSOR_PATH=~/.icons:/usr/share/icons # This is used to show the correct cursor on Wayland
 
 modules:

--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -24,7 +24,7 @@ finish-args:
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
   - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
   - --filesystem=~/.local/share/icons:ro # Needed for correct cursors on wayland 
-  - --env=XCURSOR_PATH=~/.icons:/usr/share/icons # This is used to show the correct cursor on Wayland
+  - --env=XCURSOR_PATH=~/.icons:/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
 
 modules:
   - name: Vesktop

--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -23,7 +23,9 @@ finish-args:
   - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
   - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
-  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
+  - --filesystem=~/.local/share/icons:ro # Needed for correct cursors on wayland 
+  - --filesystem=/usr/share/icons:ro
+  - --env=XCURSOR_PATH=~/.icons:/usr/share/icons # This is used to show the correct cursor on Wayland
 
 modules:
   - name: Vesktop


### PR DESCRIPTION
 Without doing it like this, I was unable to get anything other than the fallback cursor to work on Wayland. I'd understand if this is frowned upon, as it does slightly weaken the sandbox. I'd love suggestions as to other ways to accomplish this