### PR TITLE
Add ~/.icons to XCURSOR_PATH

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -23,7 +23,7 @@ finish-args:
   - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
   - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
-  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons:~/.icons # This is used to show the correct cursor on Wayland
 
 modules:
   - name: Vesktop


### PR DESCRIPTION
This solves https://github.com/Vencord/Vesktop/issues/461. I am not sure if not supporting ~/.icons is intentional though