### PR TITLE
add TTS support

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -22,6 +22,7 @@ finish-args:
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
+  - --filesystem=xdg-run/speech-dispatcher # For TTS and VcNarrator
   - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
 

--- a/startvesktop
+++ b/startvesktop
@@ -2,7 +2,7 @@
 
 export TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-dev.vencord.Vesktop}"
 
-declare -a FLAGS=(--ozone-platform-hint=auto)
+declare -a FLAGS=(--ozone-platform-hint=auto --enable-speech-dispatcher)
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [[ -c /dev/nvidia0 ]]
 then


### PR DESCRIPTION
Here's how you'd set it up in Arch
```zsh
yay -S speech-dispatcher
cat << EOF > ~/.config/systemd/user/speech-dispatcherd.service
[Unit]
Description=Speech-Dispatcher, common interface to speech synthesizers

[Service]
Type=forking
ExecStart=/usr/bin/speech-dispatcher -d -t 0
ExecReload=/bin/kill -HUP \$MAINPID

[Install]
WantedBy=default.target
EOF
systemctl --user daemon-reload
systemctl enable --now --user speech-dispatcherd.service
```
Install [Pied](https://github.com/Elleo/pied/) Flatpak and select a voice
Launch Vesktop
Enable VcNarrator plugin and play the test clips