### PR TITLE
feat: include all icon sizes

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -34,7 +34,7 @@ modules:
       - ./Vesktop.AppImage --appimage-extract
       - desktop-file-edit --set-key="Exec" --set-value="startvesktop" --set-icon=$FLATPAK_ID squashfs-root/vesktop.desktop
       - |
-        for icon in 16 32 48 64 128 256 512 1024; do
+        for icon in 16 32 48 64 128 256 512; do
           install -D squashfs-root/usr/share/icons/hicolor/${icon}x${icon}/apps/vesktop.png \
               /app/share/icons/hicolor/${icon}x${icon}/apps/dev.vencord.Vesktop.png
         done

--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -32,11 +32,12 @@ modules:
     build-commands:
       - chmod +x Vesktop.AppImage
       - ./Vesktop.AppImage --appimage-extract
-      - desktop-file-edit --set-key="Exec" --set-value="startvesktop" --set-icon=$FLATPAK_ID
-        squashfs-root/vesktop.desktop
-      - install -D squashfs-root/usr/share/icons/hicolor/512x512/apps/vesktop.png
-        /app/share/icons/hicolor/512x512/apps/dev.vencord.Vesktop.png
-      - install -D squashfs-root/usr/share/icons/hicolor/16x16/apps/vesktop.png /app/share/icons/hicolor/16x16/apps/dev.vencord.Vesktop.png
+      - desktop-file-edit --set-key="Exec" --set-value="startvesktop" --set-icon=$FLATPAK_ID squashfs-root/vesktop.desktop
+      - |
+        for icon in 16 32 48 64 128 256 512 1024; do
+          install -D squashfs-root/usr/share/icons/hicolor/${icon}x${icon}/apps/vesktop.png \
+              /app/share/icons/hicolor/${icon}x${icon}/apps/dev.vencord.Vesktop.png
+        done
       - install -D squashfs-root/vesktop.desktop /app/share/applications/dev.vencord.Vesktop.desktop
       - install -Dm755 startvesktop /app/bin/startvesktop
       - install -D dev.vencord.Vesktop.metainfo.xml -t /app/share/metainfo/


### PR DESCRIPTION
it's been reported a few times (upstream) that some applications need all of the bitmap icons, so we'll just include them all with the flatpak

fixes https://github.com/Vencord/Vesktop/issues/773