### PR TITLE
Add AppMenu support

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -17,6 +17,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE
+  - --talk-name=com.canonical.AppMenu.Registrar
   - --device=all # Needed for GPU acceleration and the webcam
   - --filesystem=xdg-videos:ro
   - --filesystem=xdg-pictures:ro


### PR DESCRIPTION
Adds support for global menu on Plasma, Unity and XFCE

Discord Flatpak
![image](https://github.com/user-attachments/assets/cdb540a8-3862-45d8-9cac-5f2937b5ad4e)
Menu is integrated into panel
Vesktop Flatpak
![image](https://github.com/user-attachments/assets/39c18a97-b414-4666-8c1a-52f0daf7c273)
Menu is not integrated into panel