### PR TITLE
Remove Wayland integration

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -12,8 +12,7 @@ separate-locales: false
 
 finish-args:
   - --socket=pulseaudio
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --share=ipc
   - --share=network
   - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE
@@ -24,7 +23,9 @@ finish-args:
   - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
   - --filesystem=xdg-run/speech-dispatcher # For TTS and VcNarrator
-  - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
+  - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode.
+                          # We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that:
+                          # 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
 
 modules:

--- a/startvesktop
+++ b/startvesktop
@@ -9,18 +9,6 @@ if [[ $XDG_SESSION_TYPE == "wayland" ]]; then
         echo "Using NVIDIA on Wayland, disabling gpu sandbox"
         FLAGS+=(--disable-gpu-sandbox)
     fi
-
-    WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
-    if [[ "${WAYLAND_SOCKET:0:1}" != "/" ]]; then
-        WAYLAND_SOCKET="$XDG_RUNTIME_DIR/$WAYLAND_SOCKET"
-    fi
-
-    if [[ -e "$WAYLAND_SOCKET" ]]; then
-        echo "Wayland socket is available, running natively on Wayland."
-        echo "To disable, remove the --socket=wayland permission."
-        FLAGS+=(--ozone-platform-hint=auto)
-        FLAGS+=(--enable-wayland-ime)
-    fi
 fi
 
 echo "Passing the following arguments to Electron:" "${FLAGS[@]}"


### PR DESCRIPTION
Also adjusts .steam comment.

This makes the Flatpak package match the experience of native packages, which use XWayland (Electron's default). Users that refuse to use XWayland will need to enable Wayland on Electron manually (preferably, this PR should only be merged next to a new Vesktop release, so Flatpak users can be informed about it).

*I have not tested and I do not plan to test any of these changes (I use the native RPM package), but I believe they should work.*

Some notes I have:

1. Does the "NVIDIA on Wayland" detection still work if only the X11 socket is exposed? 🧐
(Not sure if Flatpak overrides the `XDG_SESSION_TYPE` env. var. for the sandboxed app.)
2. Is `--socket=x11` needed for it to work? (I believe it is.)
3. There is also `--socket=inherit-wayland-socket`, but I believe it is not useful for our use-case, as we want to remove Wayland entirely (until Chromium has good native Wayland support, and Electron defaults to that).

CC @Vendicated 