### PR TITLE
Remove un-needed permissions

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -19,9 +19,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE
   - --talk-name=com.canonical.AppMenu.Registrar
   - --device=all # Needed for GPU acceleration and the webcam
-  - --filesystem=xdg-videos:ro
-  - --filesystem=xdg-pictures:ro
-  - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
+  - --filesystem=xdg-download # Used for drag-n-drop and download managing
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
   - --filesystem=xdg-run/speech-dispatcher # For TTS and VcNarrator
   - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'


### PR DESCRIPTION
Reasoning:

Users that download from Flathub, most of the time, prefer that their app is sandboxed as much as possible.

Giving access to Pictures and Videos folder seems to be random. Users may store files outside the generic OS folders (such as in an external drive, in a custom personal folder etc.). If we want to make convenient for the user, we can use `filesystem=home` or `filesystem=host` (the latter is used by OBS Studio), but I don't think we should and users should add overrides manually if needed.

`xdg-download` makes sense IMO and is fine to be kept.
Also, regarding files where the Vesktop's Flatpak does not have access, I believe XDG Portals can give access to the files temporarily.