### PR TITLE
Update Wayland IME to text-input-v3

### DIFF
--- a/startvesktop
+++ b/startvesktop
@@ -20,6 +20,7 @@ if [[ $XDG_SESSION_TYPE == "wayland" ]]; then
         echo "To disable, remove the --socket=wayland permission."
         FLAGS+=(--ozone-platform-hint=auto)
         FLAGS+=(--enable-wayland-ime)
+        FLAGS+=(--wayland-text-input-version=3)
     fi
 fi
 


### PR DESCRIPTION
Chromium recently added text-input-v3 support, but has to be explicitly enabled. This is needed as many compositors no longer support v1. Even kwin once dropped support only to re-add it because Chromium.