### PR TITLE
Remove wayland permission

### DIFF
--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -12,8 +12,7 @@ separate-locales: false
 
 finish-args:
   - --socket=pulseaudio
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --share=ipc
   - --share=network
   - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE


### PR DESCRIPTION
Electron on Wayland is still a disaster and causes major issues. We should be using XWayland by default and users can manually opt into Wayland by granting the flatpak the permission

For a better explanation, see [this comment](https://github.com/flathub/dev.vencord.Vesktop/pull/55#issuecomment-2888697811)