### PR TITLE
X11 socket to fallback to x11

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ This is the flatpak for [Vesktop](https://github.com/Vencord/Vesktop).
 Vesktop will run through Wayland by default with fallback to x11, as this is the most compatible option.
 Everything should work out of the box, including screen sharing and hardware acceleration.
 
-If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=wayland` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
+If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=wayland` and `--socket=x11-fallback` permissions with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
 
 ```sh
 flatpak override --nosocket=wayland dev.vencord.Vesktop
+flatpak override --nosocket=x11-fallback dev.vencord.Vesktop
 flatpak override --socket=x11 dev.vencord.Vesktop
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the flatpak for [Vesktop](https://github.com/Vencord/Vesktop).
 Vesktop will run through Wayland by default with fallback to x11, as this is the most compatible option.
 Everything should work out of the box, including screen sharing and hardware acceleration.
 
-If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
+If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=waylabd`` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
 
 ```sh
 flatpak override --nosocket=wayland dev.vencord.Vesktop

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the flatpak for [Vesktop](https://github.com/Vencord/Vesktop).
 Vesktop will run through Wayland by default with fallback to x11, as this is the most compatible option.
 Everything should work out of the box, including screen sharing and hardware acceleration.
 
-If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=waylabd`` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
+If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=wayland` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
 
 ```sh
 flatpak override --nosocket=wayland dev.vencord.Vesktop

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ This is the flatpak for [Vesktop](https://github.com/Vencord/Vesktop).
 
 ## Wayland
 
-Vesktop will run through X11 / XWayland by default, as this is the most compatible option.
+Vesktop will run through Wayland by default with fallback to x11, as this is the most compatible option.
 Everything should work out of the box, including screen sharing and hardware acceleration.
 
-If you wish to run it natively on Wayland instead, you can do so by removing the `--socket=x11` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following command:
+If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
 
 ```sh
-flatpak override --nosocket=x11 dev.vencord.Vesktop
+flatpak override --nosocket=wayland dev.vencord.Vesktop
+flatpak override --socket=x11 dev.vencord.Vesktop
 ```
 
 ## File access

--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -12,7 +12,7 @@ separate-locales: false
 
 finish-args:
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --share=ipc
   - --share=network

--- a/startvesktop
+++ b/startvesktop
@@ -16,7 +16,6 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
     fi
 
     echo "Running on native Wayland"
-    FLAGS+=(--ozone-platform=wayland)
     FLAGS+=(--enable-wayland-ime)
     FLAGS+=(--wayland-text-input-version=3)
 else

--- a/startvesktop
+++ b/startvesktop
@@ -17,8 +17,14 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
 
     echo "Running on native Wayland"
 else
-    echo "Running on X11"
-    echo "To use Wayland instead, use a Wayland session"
+    if [[ $XDG_SESSION_TYPE == "x11" ]]; then
+        echo "Running on native X11"
+        echo "To use Wayland instead, use a Wayland session."
+    else
+        echo "Running on X11 via Xwayland"
+        echo "The Wayland socket permission needs to be added to run on Wayland."
+    fi
+
 fi
 
 echo "Passing the following arguments to Electron:" "${FLAGS[@]}" "$@"

--- a/startvesktop
+++ b/startvesktop
@@ -18,7 +18,7 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
     echo "Running on native Wayland"
 else
     echo "Running on X11"
-    echo "To use Wayland instead, remove the --socket=x11 permission"
+    echo "To use Wayland instead, use a Wayland session"
 fi
 
 echo "Passing the following arguments to Electron:" "${FLAGS[@]}" "$@"

--- a/startvesktop
+++ b/startvesktop
@@ -16,8 +16,6 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
     fi
 
     echo "Running on native Wayland"
-    FLAGS+=(--enable-wayland-ime)
-    FLAGS+=(--wayland-text-input-version=3)
 else
     echo "Running on X11"
     echo "To use Wayland instead, remove the --socket=x11 permission"


### PR DESCRIPTION
Currently Vesktop gains access to both Wayland and x11 at the same time, which should not be the case.
Our default behavior SHOULD be to use Wayland only by default then fallback to x11 if it's the only present session.

From my own testing I have found better compatibility with voice calls including screenshare in such using this method and we boost user security.

Furthermore, we become more compliant to what is recommended within Flatpak's own sandbox permissions: https://docs.flatpak.org/en/latest/sandbox-permissions.html#standard-permissions

Finally: We no longer have to deal with XWayland issues. A similar issue covers this with: https://github.com/godotengine/godot-proposals/issues/11583#issue-2793668825

As a side benefit, I believe this will improve how secure Vesktop appears against some Flathub application managers, as we can reduce the "uses a legacy windowing system" warning.