### PR TITLE
Disable FFlags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the flatpak for [Vesktop](https://github.com/Vencord/Vesktop).
 Vesktop will run through Wayland by default with fallback to x11, as this is the most compatible option.
 Everything should work out of the box, including screen sharing and hardware acceleration.
 
-If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
+If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=waylabd`` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
 
 ```sh
 flatpak override --nosocket=wayland dev.vencord.Vesktop

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the flatpak for [Vesktop](https://github.com/Vencord/Vesktop).
 Vesktop will run through Wayland by default with fallback to x11, as this is the most compatible option.
 Everything should work out of the box, including screen sharing and hardware acceleration.
 
-If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=waylabd`` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
+If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission and removing the `--socket=wayland` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
 
 ```sh
 flatpak override --nosocket=wayland dev.vencord.Vesktop

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ This is the flatpak for [Vesktop](https://github.com/Vencord/Vesktop).
 
 ## Wayland
 
-Vesktop will run through X11 / XWayland by default, as this is the most compatible option.
+Vesktop will run through Wayland by default with fallback to x11, as this is the most compatible option.
 Everything should work out of the box, including screen sharing and hardware acceleration.
 
-If you wish to run it natively on Wayland instead, you can do so by removing the `--socket=x11` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following command:
+If you wish to run it through XWayland on Wayland instead, you can do so by adding the `--socket=x11` permission with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) or by running the following commands:
 
 ```sh
-flatpak override --nosocket=x11 dev.vencord.Vesktop
+flatpak override --nosocket=wayland dev.vencord.Vesktop
+flatpak override --socket=x11 dev.vencord.Vesktop
 ```
 
 ## File access

--- a/dev.vencord.Vesktop.yml
+++ b/dev.vencord.Vesktop.yml
@@ -12,7 +12,7 @@ separate-locales: false
 
 finish-args:
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --share=ipc
   - --share=network

--- a/startvesktop
+++ b/startvesktop
@@ -16,7 +16,6 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
     fi
 
     echo "Running on native Wayland"
-    FLAGS+=(--ozone-platform=wayland)
     FLAGS+=(--enable-wayland-ime)
     FLAGS+=(--wayland-text-input-version=3)
 else

--- a/startvesktop
+++ b/startvesktop
@@ -17,8 +17,14 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
 
     echo "Running on native Wayland"
 else
-    echo "Running on X11"
-    echo "To use Wayland instead, use a Wayland session"
+    if [[ $XDG_SESSION_TYPE == "x11" ]]; then
+        echo "Running on native X11"
+        echo "To use Wayland instead, use a Wayland session."
+    else
+        echo "Running on X11 via Xwayland"
+        echo "The Wayland socket permission needs to be added to run on Wayland."
+    fi
+
 fi
 
 echo "Passing the following arguments to Electron:" "${FLAGS[@]}" "$@"

--- a/startvesktop
+++ b/startvesktop
@@ -2,6 +2,8 @@
 
 export TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-dev.vencord.Vesktop}"
 
+declare -a FLAGS=(--enable-speech-dispatcher)
+
 if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
     WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
     if [[ "${WAYLAND_SOCKET:0:1}" != "/" ]]; then

--- a/startvesktop
+++ b/startvesktop
@@ -18,7 +18,7 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
     echo "Running on native Wayland"
 else
     echo "Running on X11"
-    echo "To use Wayland instead, remove the --socket=x11 permission"
+    echo "To use Wayland instead, use a Wayland session"
 fi
 
 echo "Passing the following arguments to Electron:" "${FLAGS[@]}" "$@"

--- a/startvesktop
+++ b/startvesktop
@@ -2,14 +2,7 @@
 
 export TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-dev.vencord.Vesktop}"
 
-declare -a FLAGS=(--enable-speech-dispatcher)
-
 if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
-    if [[ -c /dev/nvidia0 ]]; then
-        echo "Using NVIDIA on Wayland, disabling gpu sandbox"
-        FLAGS+=(--disable-gpu-sandbox)
-    fi
-
     WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
     if [[ "${WAYLAND_SOCKET:0:1}" != "/" ]]; then
         WAYLAND_SOCKET="$XDG_RUNTIME_DIR/$WAYLAND_SOCKET"

--- a/startvesktop
+++ b/startvesktop
@@ -16,8 +16,6 @@ if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
     fi
 
     echo "Running on native Wayland"
-    FLAGS+=(--enable-wayland-ime)
-    FLAGS+=(--wayland-text-input-version=3)
 else
     echo "Running on X11"
     echo "To use Wayland instead, remove the --socket=x11 permission"


### PR DESCRIPTION
Mostly self-explanatory: Avoids setting stuff we don't need to and risking user security. (We should have GPU sandboxing).
